### PR TITLE
feat: add screenshot capture and game input injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,62 @@ git clone https://github.com/Dokujaa/Godot-MCP.git
 
 3. Restart Claude Desktop and happy prompting!
 
+## Available Tools
+
+### Editor Control
+- **editor_action** — Execute an editor command (PLAY, STOP, SAVE)
+- **play_scene** — Start playing the current scene
+- **stop_scene** — Stop the currently playing scene
+- **save_all** — Save all open resources
+- **show_message** — Display a message dialog in the editor
+- **capture_screenshot** — Capture the editor viewport as an image
+- **send_game_input** — Send input commands to the running game (`move <direction> [steps]`, `interact`)
+
+### Scene Management
+- **get_scene_info** — Get info about the currently open scene
+- **open_scene** — Open a scene from the project
+- **save_scene** — Save the current scene
+- **new_scene** — Create a new empty scene
+- **create_object** — Create a new node in the scene
+- **delete_object** — Delete a node from the scene
+- **find_objects_by_name** — Search for nodes by name
+- **set_object_transform** — Set position, rotation, and scale of a node
+- **get_object_properties** — Get all properties of a node
+
+### Object Manipulation
+- **get_hierarchy** — Get the full node hierarchy of the current scene
+- **rename_node** — Rename a node in the scene
+- **set_property** — Set a property value on a node
+- **set_nested_property** — Set a nested property (e.g. material sub-properties)
+- **create_child_object** — Create a child node under a specified parent
+- **set_mesh** — Assign a mesh to a MeshInstance3D node
+- **set_collision_shape** — Set the collision shape on a collision node
+
+### Scripts
+- **view_script** — View the contents of a script file
+- **create_script** — Create a new GDScript file
+- **update_script** — Overwrite the contents of a script file
+- **list_scripts** — List all scripts in a folder
+
+### Materials
+- **set_material** — Apply or create a material on a node
+- **list_materials** — List all material assets in the project
+
+### Assets
+- **get_asset_list** — List assets in the project by type or pattern
+- **import_asset** — Import an external file into the project
+- **create_prefab** — Save a node as a packed scene (.tscn)
+- **instantiate_prefab** — Add a packed scene to the current scene
+- **import_3d_model** — Import a GLB/FBX/OBJ model into the scene
+- **list_generated_meshes** — List Meshy-generated meshes in the project
+
+### Meshy API (optional)
+- **generate_mesh_from_text** — Generate a 3D mesh from a text prompt
+- **generate_mesh_from_image** — Generate a 3D mesh from an image
+- **check_mesh_generation_progress** — Poll the status of a mesh generation job
+- **refine_generated_mesh** — Request a higher-quality refinement pass on a mesh
+- **download_and_import_mesh** — Download a completed mesh and import it into Godot
+
 ### OPTIONAL: Set up Meshy API
 
 1. Sign up for a Meshy API account at [https://www.meshy.ai/](https://www.meshy.ai/)

--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -75,6 +75,8 @@ func handle_command(command_type, params):
 			return handle_reimport_asset(params)
 		"IMPORT_GLB_SCENE":
 			return handle_import_glb_scene(params)
+		"SEND_INPUT":
+			return handle_send_input(params)
 		_:
 			return {"error": "Unknown command type: " + command_type}
 
@@ -824,12 +826,9 @@ func handle_editor_control(params):
 
 func handle_capture_screenshot(params):
 	var editor_interface = editor_plugin.get_editor_interface()
-	var viewport = editor_interface.get_editor_viewport_2d() if params.get("editor", false) else null
 	var save_path = params.get("path", "user://screenshot.png")
 	if editor_interface.is_playing_scene():
-		# During play, we can't easily grab the game viewport from the editor
-		# Save a screenshot via the editor's main viewport instead
-		pass
+		return {"error": "Screenshot during play mode is not yet supported"}
 	var main_screen = editor_interface.get_editor_main_screen()
 	var img = main_screen.get_viewport().get_texture().get_image()
 	if img == null:
@@ -839,6 +838,48 @@ func handle_capture_screenshot(params):
 		return {"error": "Failed to save screenshot: " + str(err)}
 	var abs_path = ProjectSettings.globalize_path(save_path)
 	return {"message": "Screenshot saved", "path": abs_path}
+
+func handle_send_input(params):
+	var editor_interface = editor_plugin.get_editor_interface()
+	if not editor_interface.is_playing_scene():
+		return {"error": "Game is not currently playing"}
+	var command = params.get("command", "")
+	if command == "":
+		return {"error": "Missing required parameter: command"}
+	var parts = command.strip_edges().split(" ", false)
+	if parts.size() == 0:
+		return {"error": "Empty command"}
+	if parts[0] == "interact":
+		Input.action_press("interact")
+		await editor_plugin.get_tree().create_timer(0.1).timeout
+		Input.action_release("interact")
+		return {"message": "Sent interact input"}
+	elif parts[0] == "move":
+		if parts.size() < 2:
+			return {"error": "move requires a direction: left, right, up, down"}
+		var direction = parts[1]
+		var action_map = {
+			"left": "move_left",
+			"right": "move_right",
+			"up": "move_up",
+			"down": "move_down"
+		}
+		if not action_map.has(direction):
+			return {"error": "Invalid direction '" + direction + "'. Use left, right, up, or down"}
+		var steps = 1
+		if parts.size() >= 3:
+			steps = int(parts[2])
+			if steps <= 0:
+				return {"error": "steps must be a positive integer"}
+		var action = action_map[direction]
+		for _i in range(steps):
+			Input.action_press(action)
+			await editor_plugin.get_tree().create_timer(0.1).timeout
+			Input.action_release(action)
+			await editor_plugin.get_tree().create_timer(0.05).timeout
+		return {"message": "Sent move " + direction + " x" + str(steps)}
+	else:
+		return {"error": "Unknown command '" + parts[0] + "'. Valid commands: move, interact"}
 
 # Material commands
 func handle_set_material(params):

--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -11,6 +11,8 @@ func set_editor_plugin(plugin):
 # Main command handling function
 func handle_command(command_type, params):
 	match command_type:
+		"CAPTURE_SCREENSHOT":
+			return handle_capture_screenshot(params)
 		"GET_SCENE_INFO":
 			return handle_get_scene_info()
 		"OPEN_SCENE":
@@ -819,6 +821,24 @@ func handle_editor_control(params):
 			return {"message": "Console reading not implemented in Godot"}
 		_:
 			return {"error": "Unknown editor command: " + command}
+
+func handle_capture_screenshot(params):
+	var editor_interface = editor_plugin.get_editor_interface()
+	var viewport = editor_interface.get_editor_viewport_2d() if params.get("editor", false) else null
+	var save_path = params.get("path", "user://screenshot.png")
+	if editor_interface.is_playing_scene():
+		# During play, we can't easily grab the game viewport from the editor
+		# Save a screenshot via the editor's main viewport instead
+		pass
+	var main_screen = editor_interface.get_editor_main_screen()
+	var img = main_screen.get_viewport().get_texture().get_image()
+	if img == null:
+		return {"error": "Failed to capture viewport image"}
+	var err = img.save_png(save_path)
+	if err != OK:
+		return {"error": "Failed to save screenshot: " + str(err)}
+	var abs_path = ProjectSettings.globalize_path(save_path)
+	return {"message": "Screenshot saved", "path": abs_path}
 
 # Material commands
 func handle_set_material(params):

--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -826,18 +826,29 @@ func handle_editor_control(params):
 
 func handle_capture_screenshot(params):
 	var editor_interface = editor_plugin.get_editor_interface()
-	var save_path = params.get("path", "user://screenshot.png")
+	var user_dir = OS.get_user_data_dir()
 	if editor_interface.is_playing_scene():
-		return {"error": "Screenshot during play mode is not yet supported"}
+		var trigger_path = user_dir + "/capture_request"
+		var screenshot_path = user_dir + "/game_screenshot.png"
+		var f = FileAccess.open(trigger_path, FileAccess.WRITE)
+		f.store_string("1")
+		f.close()
+		var waited = 0
+		while FileAccess.file_exists(trigger_path) and waited < 2000:
+			OS.delay_msec(50)
+			waited += 50
+		if FileAccess.file_exists(trigger_path):
+			return {"error": "Game did not respond to capture request (is DebugCapture autoload enabled?)"}
+		return {"message": "Game screenshot saved", "path": screenshot_path, "source": "game"}
 	var main_screen = editor_interface.get_editor_main_screen()
 	var img = main_screen.get_viewport().get_texture().get_image()
 	if img == null:
 		return {"error": "Failed to capture viewport image"}
+	var save_path = user_dir + "/screenshot.png"
 	var err = img.save_png(save_path)
 	if err != OK:
 		return {"error": "Failed to save screenshot: " + str(err)}
-	var abs_path = ProjectSettings.globalize_path(save_path)
-	return {"message": "Screenshot saved", "path": abs_path}
+	return {"message": "Editor screenshot saved", "path": save_path, "source": "editor"}
 
 func handle_send_input(params):
 	var editor_interface = editor_plugin.get_editor_interface()

--- a/addons/godot_mcp/command_handler.gd
+++ b/addons/godot_mcp/command_handler.gd
@@ -76,7 +76,7 @@ func handle_command(command_type, params):
 		"IMPORT_GLB_SCENE":
 			return handle_import_glb_scene(params)
 		"SEND_INPUT":
-			return handle_send_input(params)
+			return await handle_send_input(params)
 		_:
 			return {"error": "Unknown command type: " + command_type}
 

--- a/python/server.py
+++ b/python/server.py
@@ -43,7 +43,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Initialize MCP server
 mcp = FastMCP(
     "GodotMCP",
-    description="Godot Editor integration via Model Context Protocol",
+    instructions="Godot Editor integration via Model Context Protocol",
     lifespan=server_lifespan
 )
 

--- a/python/tools/editor_tools.py
+++ b/python/tools/editor_tools.py
@@ -1,7 +1,6 @@
 # tools/editor_tools.py
 from mcp.server.fastmcp import FastMCP, Context, Image
 from typing import Optional
-import base64
 from godot_connection import get_godot_connection
 
 def register_editor_tools(mcp: FastMCP):
@@ -106,19 +105,26 @@ def register_editor_tools(mcp: FastMCP):
         return editor_action(ctx, "SAVE")
 
     @mcp.tool()
-    def capture_screenshot(ctx: Context) -> str:
-        """Capture a screenshot of the Godot editor viewport and return the file path.
+    def capture_screenshot(ctx: Context, path: Optional[str] = None) -> Image:
+        """Capture a screenshot of the Godot editor viewport.
 
         Args:
             ctx: The MCP context
+            path: Optional file path to save the PNG (default: user://screenshot.png)
 
         Returns:
-            str: Path to the saved screenshot PNG file
+            Image: The captured screenshot as an image
         """
-        response = get_godot_connection().send_command("CAPTURE_SCREENSHOT", {})
-        if "error" in response:
-            return f"Error: {response['error']}"
-        return response.get("path", "Screenshot captured but path unknown")
+        try:
+            params = {}
+            if path is not None:
+                params["path"] = path
+            response = get_godot_connection().send_command("CAPTURE_SCREENSHOT", params)
+            if "error" in response:
+                raise RuntimeError(response["error"])
+            return Image(path=response["path"])
+        except Exception as e:
+            raise RuntimeError(f"Error capturing screenshot: {str(e)}")
 
     @mcp.tool()
     def send_game_input(ctx: Context, command: str) -> str:
@@ -140,7 +146,28 @@ def register_editor_tools(mcp: FastMCP):
         Returns:
             str: Success message or error details
         """
-        response = get_godot_connection().send_command("SEND_INPUT", {"command": command})
-        if "error" in response:
-            return f"Error: {response['error']}"
-        return response.get("message", "Input sent")
+        try:
+            parts = command.strip().split()
+            if not parts:
+                return "Error: Empty command"
+            if parts[0] == "interact":
+                if len(parts) != 1:
+                    return "Error: 'interact' takes no arguments"
+            elif parts[0] == "move":
+                valid_directions = {"left", "right", "up", "down"}
+                if len(parts) < 2 or parts[1] not in valid_directions:
+                    return f"Error: 'move' requires a direction: {', '.join(sorted(valid_directions))}"
+                if len(parts) == 3:
+                    if not parts[2].isdigit() or int(parts[2]) <= 0:
+                        return "Error: steps must be a positive integer"
+                elif len(parts) > 3:
+                    return "Error: 'move' takes at most 2 arguments: direction and steps"
+            else:
+                return f"Error: Unknown command '{parts[0]}'. Valid commands: move, interact"
+
+            response = get_godot_connection().send_command("SEND_INPUT", {"command": command})
+            if "error" in response:
+                return f"Error: {response['error']}"
+            return response.get("message", "Input sent")
+        except Exception as e:
+            return f"Error sending game input: {str(e)}"

--- a/python/tools/editor_tools.py
+++ b/python/tools/editor_tools.py
@@ -1,6 +1,7 @@
 # tools/editor_tools.py
-from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.fastmcp import FastMCP, Context, Image
 from typing import Optional
+import base64
 from godot_connection import get_godot_connection
 
 def register_editor_tools(mcp: FastMCP):
@@ -103,3 +104,43 @@ def register_editor_tools(mcp: FastMCP):
             str: Success message or error details
         """
         return editor_action(ctx, "SAVE")
+
+    @mcp.tool()
+    def capture_screenshot(ctx: Context) -> str:
+        """Capture a screenshot of the Godot editor viewport and return the file path.
+
+        Args:
+            ctx: The MCP context
+
+        Returns:
+            str: Path to the saved screenshot PNG file
+        """
+        response = get_godot_connection().send_command("CAPTURE_SCREENSHOT", {})
+        if "error" in response:
+            return f"Error: {response['error']}"
+        return response.get("path", "Screenshot captured but path unknown")
+
+    @mcp.tool()
+    def send_game_input(ctx: Context, command: str) -> str:
+        """Send input commands to the running Godot game.
+
+        Commands:
+            move <direction> <steps> - Move player (left/right/up/down, default 1 step)
+            interact - Press the interact button
+
+        Examples:
+            "move left 5" - move left 5 tiles
+            "move up 3" - move up 3 tiles
+            "interact" - interact with facing entity
+
+        Args:
+            ctx: The MCP context
+            command: The input command string
+
+        Returns:
+            str: Success message or error details
+        """
+        response = get_godot_connection().send_command("SEND_INPUT", {"command": command})
+        if "error" in response:
+            return f"Error: {response['error']}"
+        return response.get("message", "Input sent")


### PR DESCRIPTION
Two new editor tools:

- **capture_screenshot** — grabs the editor viewport as PNG, returns the file path. Useful for LLMs that need visual feedback of the current scene.
- **send_game_input** — sends movement and interact commands to a running game. Supports `move <direction> <steps>` and `interact`.

Also fixes the FastMCP constructor to use `instructions` instead of deprecated `description` parameter.