### PR TITLE
Fix startup crash on current mcp library and bottom-panel UI overflow

### DIFF
--- a/addons/godot_mcp/ui/mcp_panel.tscn
+++ b/addons/godot_mcp/ui/mcp_panel.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://addons/godot_mcp/ui/mcp_panel.gd" id="1_4g23r"]
 
 [node name="MCPPanel" type="Control"]
+custom_minimum_size = Vector2(0, 220)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/python/server.py
+++ b/python/server.py
@@ -43,7 +43,6 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
 # Initialize MCP server
 mcp = FastMCP(
     "GodotMCP",
-    description="Godot Editor integration via Model Context Protocol",
     lifespan=server_lifespan
 )
 


### PR DESCRIPTION
Two small fixes so the addon runs on a current setup (Godot 4.x + the latest `mcp` Python package).

1. server.py — remove unsupported `description=` kwarg. Current versions of `FastMCP` no longer accept a `description` argument, so the server crashes on startup with: `TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'`. Removing the line lets `FastMCP("GodotMCP", lifespan=server_lifespan)` start cleanly.
2. mcp_panel.tscn — give the bottom panel a minimum height. The root MCPPanel Control had no minimum size, so in Godot's bottom dock it laid out incorrectly and overlapped the editor's tab bar (Output/Debugger became unclickable). Added `custom_minimum_size = Vector2(0, 220)` so the dock sizes it properly.
Tested on Godot 4.6 / Windows.